### PR TITLE
readme manager initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+<!--BEGIN_BANNER_IMAGE--><!--END_BANNER_IMAGE-->
+
 # LiveKit Unity SDK
-This package only works on the WebGL platform of Unity
+This package only works on the WebGL platform of Unity. <!--BEGIN_DESCRIPTION--><!--END_DESCRIPTION-->
 
 ## Docs
 Docs and guides at https://docs.livekit.io
@@ -76,3 +78,5 @@ Room.DataReceived += (data, participant, kind) =>
 
 yield return Room.LocalParticipant.PublishData(Encoding.ASCII.GetBytes("This is as test"), DataPacketKind.RELIABLE);
 ```
+
+<!--BEGIN_REPO_NAV--><!--END_REPO_NAV-->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 <!--BEGIN_BANNER_IMAGE--><!--END_BANNER_IMAGE-->
 
 # LiveKit Unity SDK
-This package only works on the WebGL platform of Unity. <!--BEGIN_DESCRIPTION--><!--END_DESCRIPTION-->
+
+<!--BEGIN_DESCRIPTION-->
+This package only works on the WebGL platform of Unity.
+<!--END_DESCRIPTION-->
 
 ## Docs
 Docs and guides at https://docs.livekit.io


### PR DESCRIPTION
This PR makes the README ready to be managed by the readme manager. It adds custom comment tags to the readme, which are invisible when the README is rendered, but tell the readme manager where to insert and update content.