### PR TITLE
fix: Cannot initialize texture

### DIFF
--- a/Runtime/Scripts/Internal/HTMLVideoElement.cs
+++ b/Runtime/Scripts/Internal/HTMLVideoElement.cs
@@ -77,7 +77,9 @@ namespace LiveKit
             if (Texture != null)
                 Object.Destroy(Texture);
 
-            Texture = Texture2D.CreateExternalTexture(VideoWidth, VideoHeight, TextureFormat.RGBA32, false, true, (IntPtr)m_TextureId);
+            var width = VideoWidth > 0 ? VideoWidth : 1;
+            var height = VideoHeight > 0 ? VideoHeight : 1;
+            Texture = Texture2D.CreateExternalTexture(width, height, TextureFormat.RGBA32, false, true, (IntPtr)m_TextureId);
         }
     }
 };


### PR DESCRIPTION
Cannot initialize non-default texture with negative or zero width. This issue is the result of some API change made by Unity in 2023 version where it is no longer possible to create or resize a texture to size 0