### PR TITLE
feat: specify only the editor and WebGL platform inside the assembly

### DIFF
--- a/Runtime/livekit.unity.Runtime.asmdef
+++ b/Runtime/livekit.unity.Runtime.asmdef
@@ -2,7 +2,10 @@
     "name": "LiveKitBridge",
     "rootNamespace": "LiveKit",
     "references": [],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor",
+        "WebGL"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": false,

--- a/Runtime/livekit.unity.Runtime.asmdef.meta
+++ b/Runtime/livekit.unity.Runtime.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ae3e71e072a29bd4fb43afb30ec62dd1
+guid: ea9451ff16a9bab499ea5677a2d67939
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
Right now, there is no way to build for other platforms since the assembly in unity is set for all the platforms, with this change it will only target the editor and WebGL since those are the only platforms that this SDK is available for.

It needs to target the editor as well (even if it is not working) so it detects the code from the IDE making it easier to implement

We are using livekit for android, windows and WebGL and we are using your differents SDK for each platform meanwhile you create the universal one, this will make it possible