### PR TITLE
Supported topic on send-receive publish data, fix parameter mapping for DataReceived event.

### DIFF
--- a/Runtime/Scripts/Room/Participant/LocalParticipant.cs
+++ b/Runtime/Scripts/Room/Participant/LocalParticipant.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using UnityEngine;
 using UnityEngine.Scripting;
 
 namespace LiveKit
@@ -165,24 +166,18 @@ namespace LiveKit
 
         public JSPromise PublishData(byte[] data, int offset, int size, bool reliable, string[] destinationIdentities, string topic)
         {
-            JSArray<string> arr = null;
-            if (destinationIdentities != null)
-                arr = new JSArray<string>(destinationIdentities);
-
+            var options = new PublishDataOptions
+            {
+                Reliable = reliable,
+                DestinationIdentities = destinationIdentities,
+                Topic = topic
+            };
+           
             JSNative.PushData(data, offset, size);
-            JSNative.PushBoolean((bool)reliable);
+            JSNative.PushStruct(JsonConvert.SerializeObject(options, JSNative.JsonSettings));
 
-            if (destinationIdentities == null)
-                JSNative.PushUndefined();
-            else
-                JSNative.PushObject(arr.NativeHandle);
-
-            if(topic == null)
-                JSNative.PushUndefined();
-            else
-                JSNative.PushString(topic);
-
-            return Acquire<JSPromise>(JSNative.CallMethod(NativeHandle, "publishData"));
+            var result = JSNative.CallMethod(NativeHandle, "publishData");
+            return Acquire<JSPromise>(result);
         }
 
         public void SetTrackSubscriptionPermissions(bool allParticipantsAllowed,

--- a/Runtime/Scripts/Room/Participant/LocalParticipant.cs
+++ b/Runtime/Scripts/Room/Participant/LocalParticipant.cs
@@ -1,5 +1,4 @@
 using Newtonsoft.Json;
-using UnityEngine;
 using UnityEngine.Scripting;
 
 namespace LiveKit

--- a/Runtime/Scripts/Room/Participant/PublishDataOptions.cs
+++ b/Runtime/Scripts/Room/Participant/PublishDataOptions.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+namespace LiveKit
+{
+    public struct PublishDataOptions
+    {
+        [JsonProperty("reliable")]
+        public bool Reliable;
+        [JsonProperty("destinationIdentities")]
+        public string[] DestinationIdentities;
+        [JsonProperty("topic")]
+        public string Topic;
+    }
+}

--- a/Runtime/Scripts/Room/Participant/PublishDataOptions.cs.meta
+++ b/Runtime/Scripts/Room/Participant/PublishDataOptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96ad49a7ff429b0419ae901b5658293c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Room/Room.cs
+++ b/Runtime/Scripts/Room/Room.cs
@@ -239,7 +239,7 @@ namespace LiveKit
 
                             var topicPtr = JSNative.ShiftStack();
                             string topic = null;
-                            if (JSNative.IsString(topicPtr) && !JSNative.IsUndefined(topicPtr))
+                            if (!JSNative.IsUndefined(topicPtr) && JSNative.IsString(topicPtr))
                                 topic = JSNative.GetString(topicPtr);
 
                             Log.Debug($"Room: Received DataReceived({data}, {participant?.Sid}, {kind} {topic})");

--- a/Runtime/Scripts/Room/Room.cs
+++ b/Runtime/Scripts/Room/Room.cs
@@ -40,7 +40,7 @@ namespace LiveKit
         public delegate void ParticipantMetadataChangedDelegate(string metadata, Participant participant);
         public delegate void ActiveSpeakersChangedDelegate(JSArray<Participant> speakers);
         public delegate void RoomMetadataChangedDelegate(string metadata);
-        public delegate void DataReceivedDelegate(byte[] data, RemoteParticipant participant, DataPacketKind? kind);
+        public delegate void DataReceivedDelegate(byte[] data, RemoteParticipant participant, DataPacketKind? kind, string topic);
         public delegate void ConnectionQualityChangedDelegate(ConnectionQuality quality, Participant participant);
         public delegate void MediaDevicesErrorDelegate(JSError error);
         public delegate void TrackStreamStateChangedDelegate(RemoteTrackPublication publication, TrackStreamState streamState, RemoteParticipant participant);
@@ -237,8 +237,13 @@ namespace LiveKit
                             if (JSNative.IsNumber(kindPtr))
                                 kind = (DataPacketKind?) JSNative.GetNumber(kindPtr);
 
-                            Log.Debug($"Room: Received DataReceived({data}, {participant?.Sid}, {kind})");
-                            room.DataReceived?.Invoke(data.ToArray(), participant, kind);
+                            var topicPtr = JSNative.ShiftStack();
+                            string topic = null;
+                            if (JSNative.IsString(topicPtr) && !JSNative.IsUndefined(topicPtr))
+                                topic = JSNative.GetString(topicPtr);
+
+                            Log.Debug($"Room: Received DataReceived({data}, {participant?.Sid}, {kind} {topic})");
+                            room.DataReceived?.Invoke(data.ToArray(), participant, kind, topic);
                             break;
                         }
                     case RoomEvent.ConnectionQualityChanged:


### PR DESCRIPTION
- Updated `LocalParticipant.PublishData()` to send `PublishDataOptions` as a structured JSON, including topic, destinationIdentities, and reliable flags.
- Fix C# event handler for `RoomEvent.DataReceived` to correctly extract and forward the topic and DataPacketKind parameters from the JS stack.
- Ensures parity between WebGL and native LiveKit SDK behavior for data messages.

Previously, the WebGL build was unable to send or receive the topic associated with a data packet, as the bridge did not forward it and read it properly. This caused topic-based message handling to fail silently in WebGL builds.

Manual testing has been performed:
- Send/receive between WebGL - WebGL and WebGL - native clients (bidirectional);
- Topic defined/undefined — verified that the topic and other args are correctly propagated to receiving clients;