### PR TITLE
Referencing assembly in sample, also cleanup gitignore

### DIFF
--- a/Samples~/ExampleRoom/ExampleAssembly.asmdef
+++ b/Samples~/ExampleRoom/ExampleAssembly.asmdef
@@ -2,7 +2,8 @@
     "name": "RoomExample",
     "rootNamespace": "",
     "references": [
-        "GUID:ae3e71e072a29bd4fb43afb30ec62dd1"
+        "GUID:ae3e71e072a29bd4fb43afb30ec62dd1",
+        "GUID:ea9451ff16a9bab499ea5677a2d67939"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
In one of our samples, we were missing an assembly reference to our LiveKit code. This meant that importing the samples resulted in compile errors until you reference the assembly manually.

Also there was an unused nested `.gitignore` file I removed.